### PR TITLE
Customize minor ticks NCL_plot

### DIFF
--- a/src/geocat/viz/plot_util.py
+++ b/src/geocat/viz/plot_util.py
@@ -95,7 +95,7 @@ class NCL_Plot(ABC):
         The matplotlib.cm.ScalarMappable object that the colorbar represents. Mandatory when first creating colorbar, but not for subsequent calls.
 
     minor_per_major: obj:`list`
-        Number of minor ticks per major tick [x-axis, y-axis]. Default [3, 3] unless type="press_height".
+        Number of minor ticks per major tick [x-axis, y-axis]. Default [3, 3] unless type="press_height", then default is [3, 1].
 
     overlay: :class:`contourf.Contour`
         Reference figure that the object will be created based on. For example, when overlaying plots or creating subplots, the overlay would be the name of the first plot.
@@ -513,8 +513,9 @@ class NCL_Plot(ABC):
         if self.tick_label_fontsize is None:
             self.tick_label_fontsize = tick_label_fontsize
 
+        # if pressure height, don't add minor ticks to y-axis
         if self.type == 'press_height':
-            self.minor_per_major[1]=1
+            self.minor_per_major[1]=1    
 
         add_major_minor_ticks(ax, 
                               labelsize=str(self.tick_label_fontsize),

--- a/src/geocat/viz/plot_util.py
+++ b/src/geocat/viz/plot_util.py
@@ -94,6 +94,9 @@ class NCL_Plot(ABC):
     mappable: :class:`cartopy.mpl.contour.GeoContourSet`
         The matplotlib.cm.ScalarMappable object that the colorbar represents. Mandatory when first creating colorbar, but not for subsequent calls.
 
+    minor_per_major: obj: `tuple`
+        Number of minor ticks per major tick (x-axis, y-axis). Default (3, 3).
+
     overlay: :class:`contourf.Contour`
         Reference figure that the object will be created based on. For example, when overlaying plots or creating subplots, the overlay would be the name of the first plot.
 
@@ -264,9 +267,9 @@ class NCL_Plot(ABC):
             'individual_cb', 'label_font_size', 'lakes_on', 'land_on',
             'left_title', 'left_title_fontsize', 'line_color', 'line_style',
             'line_width', 'main_title', 'main_title_fontsize', 'mappable',
-            "overlay", 'projection', 'raxis', 'raxis_label', 'raxis_scale',
-            'raxis_tick_label_fontsize', 'raxis_ticks', 'right_title',
-            'right_title_fontsize', "set_extent", "subplot",
+            'minor_per_major', "overlay", 'projection', 'raxis', 'raxis_label', 
+            'raxis_scale', 'raxis_tick_label_fontsize', 'raxis_ticks', 
+            'right_title', 'right_title_fontsize', "set_extent", "subplot",
             'tick_label_fontsize', 'type', 'w', 'X', 'xlabel', 'xlim', "xscale",
             'xticks', 'xtick_labels', 'Y', 'ylabel', 'ylim', "yscale", 'yticks',
             'ytick_labels'
@@ -277,6 +280,7 @@ class NCL_Plot(ABC):
             'cmap': 'plasma',
             'line_color': "black",
             'line_width': 0.4,
+            'minor_per_major': (3, 3),
             'w': 8,
             'h': 8,
             'cb_orientation': "horizontal",
@@ -509,7 +513,10 @@ class NCL_Plot(ABC):
         if self.tick_label_fontsize is None:
             self.tick_label_fontsize = tick_label_fontsize
 
-        add_major_minor_ticks(ax, labelsize=str(self.tick_label_fontsize))
+        add_major_minor_ticks(ax, 
+                              labelsize=str(self.tick_label_fontsize),
+                              x_minor_per_major=self.minor_per_major[0],
+                              y_minor_per_major=self.minor_per_major[1])
 
         # if pressure height, remove right hand ticks on original axis
         if self.type == "press_height":

--- a/src/geocat/viz/plot_util.py
+++ b/src/geocat/viz/plot_util.py
@@ -94,8 +94,8 @@ class NCL_Plot(ABC):
     mappable: :class:`cartopy.mpl.contour.GeoContourSet`
         The matplotlib.cm.ScalarMappable object that the colorbar represents. Mandatory when first creating colorbar, but not for subsequent calls.
 
-    minor_per_major: obj: `tuple`
-        Number of minor ticks per major tick (x-axis, y-axis). Default (3, 3).
+    minor_per_major: obj:`list`
+        Number of minor ticks per major tick [x-axis, y-axis]. Default [3, 3] unless type="press_height".
 
     overlay: :class:`contourf.Contour`
         Reference figure that the object will be created based on. For example, when overlaying plots or creating subplots, the overlay would be the name of the first plot.
@@ -280,7 +280,7 @@ class NCL_Plot(ABC):
             'cmap': 'plasma',
             'line_color': "black",
             'line_width': 0.4,
-            'minor_per_major': (3, 3),
+            'minor_per_major': [3, 3],
             'w': 8,
             'h': 8,
             'cb_orientation': "horizontal",
@@ -512,6 +512,9 @@ class NCL_Plot(ABC):
         # Set NCL-style tick marks
         if self.tick_label_fontsize is None:
             self.tick_label_fontsize = tick_label_fontsize
+
+        if self.type == 'press_height':
+            self.minor_per_major[1]=1
 
         add_major_minor_ticks(ax, 
                               labelsize=str(self.tick_label_fontsize),

--- a/src/geocat/viz/plot_util.py
+++ b/src/geocat/viz/plot_util.py
@@ -267,8 +267,8 @@ class NCL_Plot(ABC):
             'individual_cb', 'label_font_size', 'lakes_on', 'land_on',
             'left_title', 'left_title_fontsize', 'line_color', 'line_style',
             'line_width', 'main_title', 'main_title_fontsize', 'mappable',
-            'minor_per_major', "overlay", 'projection', 'raxis', 'raxis_label', 
-            'raxis_scale', 'raxis_tick_label_fontsize', 'raxis_ticks', 
+            'minor_per_major', "overlay", 'projection', 'raxis', 'raxis_label',
+            'raxis_scale', 'raxis_tick_label_fontsize', 'raxis_ticks',
             'right_title', 'right_title_fontsize', "set_extent", "subplot",
             'tick_label_fontsize', 'type', 'w', 'X', 'xlabel', 'xlim', "xscale",
             'xticks', 'xtick_labels', 'Y', 'ylabel', 'ylim', "yscale", 'yticks',
@@ -515,9 +515,9 @@ class NCL_Plot(ABC):
 
         # if pressure height, don't add minor ticks to y-axis
         if self.type == 'press_height':
-            self.minor_per_major[1]=1    
+            self.minor_per_major[1] = 1
 
-        add_major_minor_ticks(ax, 
+        add_major_minor_ticks(ax,
                               labelsize=str(self.tick_label_fontsize),
                               x_minor_per_major=self.minor_per_major[0],
                               y_minor_per_major=self.minor_per_major[1])


### PR DESCRIPTION
Added kwarg minor_per_major to specify the number of minor ticks per major for the x and y axes. For pressure height plots, the y-axis minor_per_major is set to 1, so that no minor ticks appear on the left or right y-axis.

Resolves issue #77 