### PR TITLE
unpin matplotlib

### DIFF
--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -5,7 +5,7 @@ dependencies:
   - python>=3.8, <=3.10
   - cartopy
   - cmaps
-  - matplotlib<=3.5
+  - matplotlib
   - pint
   - pip
   - pre-commit

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python>=3.8, <=3.10
   - cartopy
   - make
-  - matplotlib<=3.5
+  - matplotlib
   - sphinx
   - pip
   - cmaps

--- a/build_envs/upstream-dev-environment.yml
+++ b/build_envs/upstream-dev-environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - jupyter
   - jupyterlab
   - make
-  - matplotlib<3.6
+  - matplotlib
   - metpy
   - mock
   - myst-nb


### PR DESCRIPTION
Some issues with colormaps had caused us to pin matplotlib.  These should now be addressed.

In particular, issue #112 was addressed by the update to cmaps and PR #125 (Julia - I think failures I saw on geocat-examples were actually because of an older version being used - I'd already mitigated the re-registration issue w/ truncate_colormap).  This PR passing should confirm.

Closes #104.

