### PR TITLE
Unit and inferred height fixes in add_height_from_pressure_axis

### DIFF
--- a/src/geocat/viz/util.py
+++ b/src/geocat/viz/util.py
@@ -307,16 +307,18 @@ def add_height_from_pressure_axis(ax,
             step = 10
 
         # Select heights to display as tick labels
-        heights = np.arange(int(height_min.magnitude), int(height_max.magnitude) + 1, step)
+        heights = np.arange(int(height_min.magnitude),
+                            int(height_max.magnitude) + 1, step)
 
     # Send selected height values back to pressure to get tick locations
-    pressures = mpcalc.height_to_pressure_std(heights * units('km')).to(pressure_units).magnitude
+    pressures = mpcalc.height_to_pressure_std(
+        heights * units('km')).to(pressure_units).magnitude
 
     # Set right-hand height axis scale to match left-hand pressure axis
     axRHS.set_yscale(ax.get_yscale())
 
-    # Turn off minor ticks that are spaced by pressure                                
-    axRHS.minorticks_off()  
+    # Turn off minor ticks that are spaced by pressure
+    axRHS.minorticks_off()
 
     set_axes_limits_and_ticks(axRHS,
                               ylim=ax.get_ylim(),

--- a/src/geocat/viz/util.py
+++ b/src/geocat/viz/util.py
@@ -283,7 +283,7 @@ def add_height_from_pressure_axis(ax,
 
     - `NCL_h_lat_7.py <https://geocat-examples.readthedocs.io/en/latest/gallery/Contours/NCL_h_lat_7.html?highlight=add_height_from_pressure_axis>`_
 
-     - `NCL_h_vector_5.py <https://geocat-examples.readthedocs.io/en/latest/gallery/Vectors/NCL_vector_5.html?highlight=add_height_from_pressure_axis>`_
+    - `NCL_h_vector_5.py <https://geocat-examples.readthedocs.io/en/latest/gallery/Vectors/NCL_vector_5.html?highlight=add_height_from_pressure_axis>`_
     """
 
     # Create the right hand axis, inheriting from the left
@@ -291,28 +291,32 @@ def add_height_from_pressure_axis(ax,
 
     # If height array isn't given, infer it from pressure axis
     if heights is None:
-        height_min, height_max = mpcalc.pressure_to_height_std(
-            ax.get_ylim() * units(pressure_units)).magnitude
+        # Calculate min and max height from pressure axis limits
+        pressure_min = np.min(ax.get_ylim()) * units(pressure_units)
+        height_max = mpcalc.pressure_to_height_std(pressure_min)
+        pressure_max = np.max(ax.get_ylim()) * units(pressure_units)
+        height_min = mpcalc.pressure_to_height_std(pressure_max)
 
         # Range and step values mirror NCL's `set_pres_hgt_axes` logic
         height_range = abs(height_max - height_min)
-        if (height_range < 35):
-            if (height_range < 70):
-                step = 7
-            else:
-                step = 4
+        if (height_range <= 35 * units('km')):
+            step = 4
+        elif (height_range <= 70 * units('km')):
+            step = 7
         else:
             step = 10
 
         # Select heights to display as tick labels
-        heights = np.arange(int(height_min), int(height_max) + 1, step)
+        heights = np.arange(int(height_min.magnitude), int(height_max.magnitude) + 1, step)
 
     # Send selected height values back to pressure to get tick locations
-    pressures = mpcalc.height_to_pressure_std(heights * units('km')).magnitude
+    pressures = mpcalc.height_to_pressure_std(heights * units('km')).to(pressure_units).magnitude
 
-    # Display logrithmically to match right-hand pressure axis
-    axRHS.set_yscale('log')
-    axRHS.minorticks_off()  # Turn off minor ticks that are spaced by pressure
+    # Set right-hand height axis scale to match left-hand pressure axis
+    axRHS.set_yscale(ax.get_yscale())
+
+    # Turn off minor ticks that are spaced by pressure                                
+    axRHS.minorticks_off()  
 
     set_axes_limits_and_ticks(axRHS,
                               ylim=ax.get_ylim(),


### PR DESCRIPTION
Some fixes in `add_height_from_pressure_axis`:
* Converts pressure units back to the specified `pressure_units` so that the function will work with datasets not in hPa (e.g. in Pa as in #150)
* Fixes a bit of logic in the height array generation code for calculating the step
* Makes the height array generation code a bit more flexible so it doesn't matter if the y axis is inverted or not

This will only impact cases where heights are not specified and/or pressure units are not hPa (i.e. none of the geocat-examples or usage examples).

Closes #150.