### PR TITLE
Fix to extlinks for compatibility with Sphinx 6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,8 +82,8 @@ intersphinx_mapping = {
 }
 # allows us to easily link PRs and issues in the change log
 extlinks = {
-    "issue": ("https://github.com/NCAR/geocat-viz/issues/%s", "GH"),
-    "pr": ("https://github.com/NCAR/geocat-viz/pull/%s", "PR"),
+    "issue": ("https://github.com/NCAR/geocat-viz/issues/%s", "GH%s"),
+    "pr": ("https://github.com/NCAR/geocat-viz/pull/%s", "PR%s"),
 }
 
 # napoleon settings

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,6 +16,7 @@ Documentation
 Bug Fixes
 ^^^^^^^^^
 * Remove matplotlib version pin by `Katelyn FitzGerald`_ in (:pr:`177`)
+* Fix `extlinks` for compatibility with Sphinx 6 by `Katelyn FitzGerald`_ in (:pr:`180`)
 
 v2023.10.0 (October 3, 2023)
 ----------------------------


### PR DESCRIPTION
## PR Summary
Sphinx 6+ broke compatibility with how we had extlinks configured.

Closes #179

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [ ] Make an issue if one doesn't already exist
- [ ] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [ ] Add appropriate labels to this PR
- [ ] Make your changes in a forked repository rather than directly in this repo
- [ ] Open this PR as a draft if it is not ready for review
- [ ] Convert this PR from a draft to a full PR before requesting reviewers
- [ ] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.