### PR TITLE
fix docstring of Taylor Diagram add_model_set()

### DIFF
--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -201,10 +201,10 @@ class TaylorDiagram(object):
 
         Parameters
         ----------
-        stddev : :class:`xarray.DataArray`, :class:`numpy.ndarray`, list, float
+        stddev : :class:`xarray.DataArray`, :class:`numpy.ndarray`, list
             An array of vertical coordinates of the data points that denote the standard deviation
 
-        corrcoef : :class:`xarray.DataArray`, :class:`numpy.ndarray`, list, float
+        corrcoef : :class:`xarray.DataArray`, :class:`numpy.ndarray`, list
             An array of horizontal coordinates of the data points that denote correlation
             Input should have the same size as *stddev*
 
@@ -226,7 +226,7 @@ class TaylorDiagram(object):
         percent_bias_on : bool
             If True, model marker and marker size is plotted based on *bias_array* Default to False. Optional.
 
-        bias_array : :class:`xarray.DataArray`, :class:`numpy.ndarray`, list, float
+        bias_array : :class:`xarray.DataArray`, :class:`numpy.ndarray`, list
             If this is given, it is used to determine individual marker size and marker style internally.
             Input should have the same size as *stddev* and *corrcoef* Default to None.
 


### PR DESCRIPTION
## PR Summary
It says it takes floats but doesn't
Related to #176 

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.

**Documentation**
- [x] Docstrings have been added to all new functions
- [x] Docstrings have been updated with any function changes
- [x] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [x] User facing functions have been added to `docs/user_api/index.rst` under their module

