### PR TITLE
Python 3.12 support and Windows and M1 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest"]
-        python-version: [ "3.9", "3.10", "3.11" ]
+        os: [ "ubuntu-latest", "macos-latest", "macos-14", "windows-latest"]
+        python-version: [ "3.9", "3.11", "3.12" ]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -32,13 +32,23 @@ jobs:
           token: ${{ github.token }}
       - name: conda_setup
         uses: conda-incubator/setup-miniconda@v2
+        if: matrix.os != 'macos-14'
         with:
           activate-environment: geocat_viz_build
           channel-priority: strict
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
           environment-file: build_envs/environment.yml
-
+      - name: conda_setup_m1
+        uses: conda-incubator/setup-miniconda@v2
+        if: matrix.os == 'macos-14'
+        with:
+          installer-url: https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh
+          activate-environment: geocat_viz_build
+          channel-priority: strict
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          environment-file: build_envs/environment.yml
       - name: Install geocat-viz
         run: |
           python -m pip install . --no-deps

--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -2,7 +2,7 @@ name: gv-docs
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9, <3.12
+  - python>=3.9, <3.13
   - cartopy
   - cmaps
   - matplotlib

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -2,7 +2,7 @@ name: geocat_viz_build
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9, <3.12
+  - python>=3.9, <3.13
   - cartopy
   - make
   - matplotlib

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,6 +11,7 @@ v2024.1.0 (Unreleased)
 New Features
 ^^^^^^^^^^^^
 * Added subtitle functionality to `set_titles_and_labels()` by `Julia Kent`_ in (:pr:`185`)
+* Added Python 3.12 support and testing for Windows and M1 by `Katelyn FitzGerald`_ in (:pr:`194`)
 
 Documentation
 ^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,13 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
 
 [options]
 zip_safe = False
 include_package_data = True
-python_requires = >=3.9, <3.12
+python_requires = >=3.9, <3.13
 package_dir =
     =src
 packages =


### PR DESCRIPTION
## PR Summary
Adds Python 3.12 support and Windows and M1 to test matrix.

For what it's worth, it looks like the M1 runners are slated to [become macos-latest sometime in late spring / summer of 2024](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/).   

Closes #167 and #193

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
