### PR TITLE
PypI Trusted Publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -28,6 +28,8 @@ jobs:
     needs: test-build
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -49,7 +51,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_GEOCAT_VIZ }}
-          skip_existing: true
+          skip-existing: true
           verbose: true

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -10,7 +10,7 @@ v2024.03.0 (Unreleased)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
-* Switch to PyPI Trusted Publishing by `Orhan Eroglu`_ in (:pr:``)
+* Switch to PyPI Trusted Publishing by `Orhan Eroglu`_ in (:pr:`208`)
 
 v2024.02.0 (February 6, 2024)
 -----------------------------

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,6 +5,13 @@
 Release Notes
 =============
 
+v2024.03.0 (Unreleased)
+-----------------------
+
+Internal Changes
+^^^^^^^^^^^^^^^^
+* Switch to PyPI Trusted Publishing by `Orhan Eroglu`_ in (:pr:``)
+
 v2024.02.0 (February 6, 2024)
 -----------------------------
 This release adds a new subtitle functionality to ``set_titles_and_labels`` and
@@ -109,3 +116,4 @@ Documentation
 
 .. _`Julia Kent`: https://github.com/jukent
 .. _`Katelyn Fitzgerald`: https://github.com/kafitzgerald
+.. _`Orhan Eroglu`: https://github.com/erogluorhan


### PR DESCRIPTION
## PR Summary

Closes #183 

## Re reviewers:

Sorry, I forgot to create this from a fork. Please let me know if we are good or I still need to do that.

## Overview

This PR just removes the PyPI secret from the `pypi.yaml` action since we've added repo as a trusted publisher on PyPI:

<img width="667" alt="image" src="https://github.com/NCAR/geocat-viz/assets/32553057/26348ba7-58ac-45ac-b710-af48bb8648fc">

Once PyPi releases start to work with this and the first one succeed, we should be good to remove the secret from the repo settings.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.