### PR TITLE
Update docs environment to avoid Xarray bug

### DIFF
--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -13,7 +13,7 @@ dependencies:
   - myst-nb
   - nbsphinx
   - sphinx-design
-  - xarray
+  - xarray!=2024.11.0
   - geocat-datafiles
   - pip:
       - -e ..


### PR DESCRIPTION
## PR Summary
This PR changes the documentation environment specification file to skip Xarray v2024.11.0 with the colormap specification / seaborn import bug.  It intentionally doesn't change other environment specification files or the package requirements since this is a rather narrow bug that only impacts our examples because of how we specify colormaps and not something related to geocat-viz itself or broadly impacting Xarray.  For this reason I didn't update the release notes either though I can if that is helpful for internal notes.

Closes #262

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
