### PR TITLE
Taylor diagram legend axis fix

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,10 @@ Release Notes
 v2024.xx.0 (unreleased)
 ---------------------------
 
+Bug Fixes
+^^^^^^^^^
+* Change Taylor diagram legend to be specified on the graphical axes to address legend location issues by `Katelyn FitzGerald`_ in (:pr:`273`)
+
 Documentation
 ^^^^^^^^^^^^^
 * Remove link to broken NCL_vector_5.py example by `Katelyn FitzGerald`_ in (:pr:`249`)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -10,7 +10,7 @@ v2024.xx.0 (unreleased)
 
 Bug Fixes
 ^^^^^^^^^
-* Change Taylor diagram legend to be specified on the graphical axes to address legend location issues by `Katelyn FitzGerald`_ in (:pr:`273`)
+* Change Taylor diagram legend to be specified on the graphical axes to address legend location issues by `Katelyn FitzGerald`_ in (:pr:`274`)
 
 Documentation
 ^^^^^^^^^^^^^

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -719,12 +719,12 @@ class TaylorDiagram(object):
         if kwargs.get('labels') is None:
             labels = [p.get_label() for p in handles]
 
-        legend = self.ax.legend(handles,
-                                labels,
-                                loc=loc,
-                                bbox_to_anchor=(xloc, yloc),
-                                fontsize=fontsize,
-                                frameon=False)
+        legend = self._ax.legend(handles,
+                                 labels,
+                                 loc=loc,
+                                 bbox_to_anchor=(xloc, yloc),
+                                 fontsize=fontsize,
+                                 frameon=False)
         return legend
 
     def add_title(self,


### PR DESCRIPTION
## PR Summary
Changes the Taylor diagram `add_legend` method to use the "graphical axes" rather than the floating axes.

I did test this locally on Matplotlib 3.9.0, 3.10.0, and 3.10.1 and in doing so noticed that there's not a diff with the existing baseline image for Matplotlib 3.9.0, 3.10.0.  Though the versions don't line up with those described in the deprecation warning, I suspect this might indicate the recent CI failures with 3.10.1 might have something to do with these Matplotlib changes (as mentioned in #273) impacting the floating axes and therefore the legend location as specified on there.  This change should hopefully make the legend location specific a bit more robust and resolve the CI failures.

Closes #271

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
