### PR TITLE
Address Matplotlib deprecation of apply_theta_transforms

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -26,7 +26,7 @@ Internal Changes
 * Modify tests to avoid hitting an unrelated Xarray bug and turn on image comparison testing by `Katelyn FitzGerald`_ in (:pr:`257`)
 * Configure analytics by `Katelyn FitzGerald`_ in (:pr:`277`)
 * Set `apply_theta_transforms=False` to adopt future behavior and silence warnings from
-`matplotlib.projections.PolarAxes.PolarTransform()` by `Katelyn FitzGerald`_ in (:pr:`278`)
+`matplotlib.projections.PolarAxes.PolarTransform()` by `Katelyn FitzGerald`_ in (:pr:`279`)
 
 Testing
 ^^^^^^^

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -25,6 +25,8 @@ Internal Changes
 * Remove M1 workaround for CI and tokens that are no longer needed by `Katelyn FitzGerald`_ in (:pr:`232`)
 * Modify tests to avoid hitting an unrelated Xarray bug and turn on image comparison testing by `Katelyn FitzGerald`_ in (:pr:`257`)
 * Configure analytics by `Katelyn FitzGerald`_ in (:pr:`277`)
+* Set `apply_theta_transforms=False` to adopt future behavior and silence warnings from
+`matplotlib.projections.PolarAxes.PolarTransform()` by `Katelyn FitzGerald`_ in (:pr:`278`)
 
 Testing
 ^^^^^^^

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -100,7 +100,7 @@ class TaylorDiagram(object):
         self.smax = std_range[1]
 
         # Set polar transform
-        tr = PolarAxes.PolarTransform()
+        tr = PolarAxes.PolarTransform(apply_theta_transforms=False)
 
         # Set correlation labels
         rlocs = np.concatenate((np.arange(10) / 10., [0.95, 0.99, 1]))


### PR DESCRIPTION
## PR Summary
Adopts future behavior and silences deprecation warning from Matplotlib by setting `apply_theta_transforms=False` for `PolarTransform`.

As far as I can tell (through testing the Taylor Digram code which is the only thing that would be impacted), we aren't actually relying up this in our code.

This should force the new behavior so we can adapt if needed.   

Closes #273

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
