### PR TITLE
Raise a Sphinx build error on docs notebook errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -369,6 +369,7 @@ def update_gallery(app: Sphinx):
 # set to "off" to turn off
 # set to "auto" for default behavior
 nb_execution_mode = "force"
+nb_execution_raise_on_error = True
 
 # generate warning for all invalid links
 #nitpicky = True

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -36,7 +36,7 @@ Testing
 * Add tests for `viz.taylor` by `Julia Kent`_ in (:pr:`234`)
 * Add tests for `viz.util` by `Julia Kent`_ in (:pr:`239`)
 * Remove now duplicative macOS runner from CI and add back in Python 3.10 by `Katelyn FitzGerald`_ in (:pr:`240`)
-
+* Set docs configuration to raise an error when there are errors in notebook builds by `Katelyn FitzGerald`_ in (:pr:`280`)
 
 v2024.03.0 (March 26, 2024)
 ---------------------------


### PR DESCRIPTION
## PR Summary
Adjusts a docs setting to raise an error rather than a warning on docs notebook errors.  This should help us catch things like #262.

It looks like you can also address this as a build flag, but I like this better here I think and it's what Project Pythia is using.
[nb_execution_raise_on_error](https://myst-nb.readthedocs.io/en/latest/computation/execute.html#error-reporting-warning-vs-failure)

I think should cause our ReadTheDocs builds to fail if there are errors in running the example notebooks, but haven't tested that and unlike Pythia that's where we are doing our  docs builds.

Closes #263

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.