### PR TITLE
Require matplotlib-base instead of matplotlib and some overall dependency cleanup

### DIFF
--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - cartopy
   - cmaps
-  - matplotlib
+  - matplotlib-base
   - pandas
   - pint
   - xarray

--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -8,13 +8,10 @@ dependencies:
   - matplotlib
   - pandas
   - pint
-  - pip
+  - xarray
   - pre-commit
   - sphinx-book-theme
   - myst-nb
   - nbsphinx
   - sphinx-design
-  - xarray!=2024.11.0
   - geocat-datafiles
-  - pip:
-      - -e ..

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -1,19 +1,20 @@
 name: geocat_viz_build
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - cartopy
-  - make
   - matplotlib
-  - sphinx
   - cmaps
   - numpy
   - xarray
   - metpy
   - pandas
   - pint
+  - scikit-learn
+# testing
   - pytest
   - pytest-mpl
   - geocat-datafiles
+# formatting
   - pre-commit
-  - scikit-learn

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - cartopy
-  - matplotlib
+  - matplotlib-base
   - cmaps
   - numpy
   - xarray

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -41,6 +41,10 @@ Testing
 * Set docs configuration to raise an error when there are errors in notebook builds by `Katelyn FitzGerald`_ in (:pr:`280`)
 * Add upstream dev CI by `Katelyn FitzGerald`_ in (:pr:`282`)
 
+Maintenance
+^^^^^^^^^^^
+* Require matplotlib-base instead of matplotlib and some minor dependency cleanup by `Katelyn FitzGerald`_ in (:pr:`285`)
+
 v2024.03.0 (March 26, 2024)
 ---------------------------
 This release deprecates ``TaylorDiagram`` method names ``add_xgrid()`` and

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -43,7 +43,7 @@ Testing
 
 Maintenance
 ^^^^^^^^^^^
-* Require matplotlib-base instead of matplotlib and some minor dependency cleanup by `Katelyn FitzGerald`_ in (:pr:`285`)
+* Require matplotlib-base instead of matplotlib and some minor dependency cleanup by `Katelyn FitzGerald`_ in (:pr:`284`)
 
 v2024.03.0 (March 26, 2024)
 ---------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
     setuptools
     pip
 install_requires =
-    matplotlib-base
+    matplotlib
     xarray
     numpy
     cartopy
@@ -56,7 +56,7 @@ docs =
     ipython
     sphinx_rtd_theme
     jupyter_client
-    matplotlib-base
+    matplotlib
     sphinx-book-theme
     myst-nb
     sphinx-design

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,11 @@ setup_requires =
     setuptools
     pip
 install_requires =
-    matplotlib
+    matplotlib-base
     xarray
     numpy
     cartopy
     cmaps
-    setuptools
     scikit-learn
     metpy
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,9 @@ install_requires =
     numpy
     cartopy
     cmaps
-    scikit-learn
     metpy
+    pint
+    scikit-learn
 tests_require =
     pytest
     pytest-mpl


### PR DESCRIPTION
## PR Summary
* Require matplotlib-base instead of matplotlib in Conda envs per the [recommendation here ](https://conda-forge.org/docs/maintainer/knowledge_base/#matplotlib)(and reminder over on the feedstock repo)
* Add `nodefaults` channel where missing from env specification
* Add `pint` to requirements in our setup.cfg since we do need it at this point
* Minor reorganization

Relates to #266 (I'll close this once things have been updated in the feedstock repo and released)

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
