### PR TITLE
Update Skew-T test

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,7 +16,7 @@ Testing
 ^^^^^^^
 * Add minimum dependency version testing and address minor compatibility issues with Matplotlib by `Katelyn FitzGerald`_ in (:pr:`291`)
 * Move to setup-micromamba for environments in CI by `Katelyn FitzGerald`_ in (:pr:`294`)
-* Adapt tests to accomodate upstream changes in the MetPy CAPE calculations by `Katelyn FitzGerald`_ in (:pr:`299`)
+* Adapt tests to accomodate upstream changes in MetPy for LCL and CAPE by `Katelyn FitzGerald`_ in (:pr:`299`, :pr:`300`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -290,4 +290,4 @@ def test_get_skewt_vars():
     if metpy_version < Version('1.7'):
         assert subtitle == 'Plcl= 927 Tlcl[C]= 24 Shox= 3 Pwat[cm]= 5 Cape[J]= 3135'
     else:
-        assert subtitle == 'Plcl= 927 Tlcl[C]= 24 Shox= 3 Pwat[cm]= 5 Cape[J]= 3212'
+        assert subtitle == 'Plcl= 926 Tlcl[C]= 24 Shox= 3 Pwat[cm]= 5 Cape[J]= 3212'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -290,4 +290,4 @@ def test_get_skewt_vars():
     if metpy_version < Version('1.7'):
         assert subtitle == 'Plcl= 927 Tlcl[C]= 24 Shox= 3 Pwat[cm]= 5 Cape[J]= 3135'
     else:
-        assert subtitle == 'Plcl= 927 Tlcl[C]= 24 Shox= 3 Pwat[cm]= 5 Cape[J]= 3261'
+        assert subtitle == 'Plcl= 927 Tlcl[C]= 24 Shox= 3 Pwat[cm]= 5 Cape[J]= 3212'


### PR DESCRIPTION
## PR Summary
Updates the `test_get_skewt_vars` test to account for additional upstream changes in MetPy.

This isn't the most robust, but should pass for MetPy releases and avoid more false alarms.

It'd be better to adapt the test so it's less sensitive to changes from MetPy, but I don't really want to spend time on that at the moment.

Closes #298

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
