### PR TITLE
Update Taylor diagram code to support Matplotlib 3.11

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,6 +12,10 @@ Documentation
 ^^^^^^^^^^^^^
 * Remove reference to NCAR/geocat repo from support page by `Katelyn FitzGerald`_ in (:pr:`293`)
 
+Enhancements
+^^^^^^^^^^^^
+* Adapt Taylor diagram code for compatibility with Matplotlib 3.11 by `Katelyn FitzGerald`_ in (:pr:`308`)
+
 Testing
 ^^^^^^^
 * Add minimum dependency version testing and address minor compatibility issues with Matplotlib by `Katelyn FitzGerald`_ in (:pr:`291`)

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -106,8 +106,10 @@ class TaylorDiagram(object):
         mpl_version = Version(matplotlib.__version__)
         if mpl_version < Version('3.9'):
             tr = PolarAxes.PolarTransform(_apply_theta_transforms=False)
-        else:
+        elif mpl_version < Version('3.11'):
             tr = PolarAxes.PolarTransform(apply_theta_transforms=False)
+        else:
+            tr = PolarAxes.PolarTransform()
 
         # Set correlation labels
         rlocs = np.concatenate((np.arange(10) / 10.0, [0.95, 0.99, 1]))


### PR DESCRIPTION
## PR Summary
Minor change to Taylor diagram code to support Matplotlib 3.11.

This accounts for the removal of the `apply_theta_transforms` argument in Matplotlib 3.11.  We were just using this to impose to the new defaults anyway so no big changes needed here just another conditional based upon the Matplotlib version.

Closes #307

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
