### PR TITLE
Update Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "miniforge3-latest"
   jobs:
     post_create_environment:
       - python -m pip install --no-cache-dir .


### PR DESCRIPTION
Updates the Read the Docs dependencies.

Prompted by some recent [guidance](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/) on OS deprecation from Read the Docs and a quick review of the current docs for the config file.

Relates to: https://github.com/NCAR/geocat-planning/issues/37