### PR TITLE
Temporarily pin micromamba version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - name: environment setup
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          micromamba-version: '2.6.0-0'
           environment-file: ${{ env.CONDA_ENV_FILE }}
           create-args: >-
             python=${{ matrix.python-version }}

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -22,6 +22,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * Group Dependabot updates by `Katelyn FitzGerald`_ in (:pr:`323`)
 * Automatic issue generation for CI Upstream failure by `Katelyn FitzGerald`_ in (:pr:`348`, :pr:`351`)
+* Pin micromamba version in CI by `Katelyn FitzGerald`_ in (:pr:`354`)
 
 v2025.07.0 (July 16, 2025)
 --------------------------


### PR DESCRIPTION
## PR Summary
Temporarily pin the micromamba version in CI to avoid failures on the Window builds.

Closes #353 

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.