### PR TITLE
Increase tolerances on image tests for Matplotlib 3.11 and explicitly set Taylor plot tick direction

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,6 +11,7 @@ This release...
 
 Testing
 ^^^^^^^
+* Increase image test tolerances to support Matplotlib 3.11 by `Katelyn FitzGerald`_ in (:pr:`363`)
 * Manually specify contour levels in tests by `Katelyn FitzGerald`_ in (:pr:`321`)
 
 Documentation

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -162,10 +162,11 @@ class TaylorDiagram(object):
         ax.axis["right"].major_ticklabels.set_axis_direction("left")
         ax.axis["right"].label.set_text("Standard deviation (Normalized)")
 
-        # Set font sizes, tick sizes, and padding
+        # Set font sizes, tick settings, and padding
         ax.axis['top', 'right'].label.set_fontsize(18)
         ax.axis['top', 'right', 'left'].major_ticklabels.set_fontsize(16)
         ax.axis['top', 'right', 'left'].major_ticks.set_ticksize(10)
+        ax.axis['top', 'right', 'left'].major_ticks.set_tick_direction("in")
         ax.axis['top', 'right', 'left'].major_ticklabels.set_pad(8)
         ax.axis['top', 'right'].label.set_pad(6)
 

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -166,7 +166,8 @@ class TaylorDiagram(object):
         ax.axis['top', 'right'].label.set_fontsize(18)
         ax.axis['top', 'right', 'left'].major_ticklabels.set_fontsize(16)
         ax.axis['top', 'right', 'left'].major_ticks.set_ticksize(10)
-        ax.axis['top', 'right', 'left'].major_ticks.set_tick_direction("in")
+        if mpl_version in SpecifierSet(">=3.11", prereleases=True):
+            ax.axis['top', 'right', 'left'].major_ticks.set_tick_direction("in")
         ax.axis['top', 'right', 'left'].major_ticklabels.set_pad(8)
         ax.axis['top', 'right'].label.set_pad(6)
 

--- a/tests/test_taylor.py
+++ b/tests/test_taylor.py
@@ -5,7 +5,7 @@ import numpy as np
 from geocat.viz.taylor import TaylorDiagram
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=17, remove_text=True, style='default')
 def test_add_model_set():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')
@@ -21,7 +21,7 @@ def test_add_model_set():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=18, remove_text=True, style='default')
 def test_add_legend():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')
@@ -51,7 +51,7 @@ def test_add_legend():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=17.5, remove_text=True, style='default')
 def test_add_bias_legend():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')
@@ -71,7 +71,7 @@ def test_add_bias_legend():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=17.4, remove_text=True, style='default')
 def test_add_model_name():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')
@@ -91,7 +91,7 @@ def test_add_model_name():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=17, remove_text=True, style='default')
 def test_add_corr_grid():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')
@@ -111,7 +111,7 @@ def test_add_corr_grid():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=16.7, remove_text=True, style='default')
 def test_add_contours():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')

--- a/tests/test_taylor.py
+++ b/tests/test_taylor.py
@@ -111,7 +111,7 @@ def test_add_corr_grid():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=16.7, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=16.8, remove_text=True, style='default')
 def test_add_contours():
     fig = plt.figure(figsize=(10, 10))
     taylor = TaylorDiagram(fig=fig, label='REF')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -42,7 +42,7 @@ def test_set_tick_direction_spine_visibility():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=11.3, remove_text=True, style='default')
 def test_add_lat_lon_gridlines():
     fig = plt.figure(figsize=(10, 10))
 
@@ -59,7 +59,7 @@ def test_add_lat_lon_gridlines():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=7.9, remove_text=True, style='default')
 def test_add_right_hand_axis():
     fig = plt.figure(figsize=(9, 10))
     ax1 = plt.gca()
@@ -75,7 +75,7 @@ def test_add_right_hand_axis():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=6.1, remove_text=True, style='default')
 def test_add_height_from_pressure_axis():
     fig = plt.figure(figsize=(8, 8))
     ax = plt.axes()
@@ -109,7 +109,7 @@ def test_add_major_minor_ticks():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=3.4, remove_text=True, style='default')
 def test_set_titles_and_labels():
     fig = fig, ax = plt.subplots()
 
@@ -333,7 +333,7 @@ def test_find_local_extrema():
     assert lmin == (2, 2)
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=10.9, remove_text=True, style='default')
 def test_plot_contour_labels():
     ds = xr.open_dataset(gdf.get("netcdf_files/slp.1963.nc"), decode_times=False)
     pressure = ds.slp[24, :, :].astype('float64') * 0.01
@@ -366,7 +366,7 @@ def test_plot_contour_labels():
     return fig
 
 
-@pytest.mark.mpl_image_compare(tolerance=2, remove_text=True, style='default')
+@pytest.mark.mpl_image_compare(tolerance=7.3, remove_text=True, style='default')
 def test_plot_extrema_labels():
     ds = xr.open_dataset(gdf.get("netcdf_files/slp.1963.nc"), decode_times=False)
     pressure = ds.slp[24, :, :].astype('float64') * 0.01


### PR DESCRIPTION
## PR Summary

Increases tolerances on image tests for Matplotlib 3.11 and explicitly sets the Taylor plot tick direction to avoid changes with the new defaults.

Another option here would be to include another set of baseline images for v3.11+ and adapt our tests accordingly.  I think this (i.e. two sets of baseline images) is probably the better approach, but don't have time at the moment.

Closes #362 

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
