### PR TITLE
Address docs warnings and adjust CI Upstream runs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -7,8 +7,6 @@
    :exclude-members: __init__
 
    {% block methods %}
-   .. automethod:: method
-
    {% if methods %}
    .. rubric:: {{ _('Methods') }}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,7 +220,6 @@ html_theme_options = {
     "use_repository_button": True,
     "use_issues_button": True,
     "home_page_in_toc": False,
-    "navbar_footer_text": "",
     "logo": {
         "image_light": '_static/images/logos/NSF_NCAR_light.png',
         "image_dark": '_static/images/logos/NSF_NCAR_dark.png',

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -101,7 +101,7 @@ Documentation
 * Document known issue with `suptitle` argument of  ``set_titles_and_labels`` and Cartopy plots by `Julia Kent`_ in (:pr:`219`)
 
 Deprecations
-^^^^^^^^^^
+^^^^^^^^^^^^
 * Pending deprecation warnings added for ``TaylorDiagram`` methods ``add_xgrid`` and ``add_ygrid`` which are changing to the new ``add_corr_grid`` and ``add_std_grid`` by `Julia Kent`_ in (:pr:`219`)
 
 v2024.02.1 (February 28, 2024)
@@ -180,7 +180,7 @@ v2023.07.0 (July 6, 2023)
 Matplotlib unpinned and an examples gallery added.
 
 Bug Fixes
-^^^^^^^^^^^^
+^^^^^^^^^
 * Matplotlib unpinned by `Katelyn Fitzgerald`_ in (:pr:`134`)
 
 Documentation

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -23,6 +23,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * Group Dependabot updates by `Katelyn FitzGerald`_ in (:pr:`323`)
 * Automatic issue generation for CI Upstream failure by `Katelyn FitzGerald`_ in (:pr:`348`, :pr:`351`)
+* Address docs warnings and adjust CI Upstream runs by `Katelyn FitzGerald`_ in (:pr:`366`)
 
 v2025.07.0 (July 16, 2025)
 --------------------------

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -268,7 +268,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-        - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_model_set>`_
+        - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_model_set>`__
         """
 
         # Convert to np arrays and make copies
@@ -446,7 +446,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-        - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_corr_grid>`_
+        - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_corr_grid>`__
         """
 
         for value in arr:
@@ -520,7 +520,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-         - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_std_grid>`_
+         - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_std_grid>`__
         """
 
         t_array = np.linspace(0, np.pi / 2)
@@ -590,7 +590,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-         - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_contours>`_
+         - `NCL_taylor_2.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_2.html?highlight=add_contours>`__
         """
         # Return coordinate matrices from coordinate vectors
         rs, ts = np.meshgrid(
@@ -648,9 +648,9 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-        - `NCL_taylor_3.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_3.html?highlight=add_model_name>`_
+        - `NCL_taylor_3.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_3.html?highlight=add_model_name>`__
 
-        - `NCL_taylor_6.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_6.html?highlight=add_model_name>`_
+        - `NCL_taylor_6.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_6.html?highlight=add_model_name>`__
         """
 
         text = [str(i + 1) + ' - ' + namearr[i] for i in range(len(namearr))]
@@ -762,7 +762,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-        - `NCL_taylor_3.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_3.html?highlight=add_legend>`_
+        - `NCL_taylor_3.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_3.html?highlight=add_legend>`__
         """
 
         if kwargs.get('handles') is None:
@@ -808,7 +808,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-        - `NCL_taylor_6.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_6.html?highlight=add_title>`_
+        - `NCL_taylor_6.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_6.html?highlight=add_title>`__
         """
 
         self._ax.set_title(maintitle, fontsize=fontsize, y=y_loc, **kwargs)
@@ -840,7 +840,7 @@ class TaylorDiagram(object):
         --------
         All usage examples are within the GeoCAT-Examples Gallery. To see more usage cases, search the function on the `website <https://geocat-examples.readthedocs.io/en/latest/index.html>`_.
 
-        - `NCL_taylor_6.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_6.html?highlight=set_fontsize_and_pad>`_
+        - `NCL_taylor_6.py <https://geocat-examples.readthedocs.io/en/latest/gallery/TaylorDiagrams/NCL_taylor_6.html?highlight=set_fontsize_and_pad>`__
         """
 
         self._ax.axis['top', 'right', 'left'].major_ticklabels.set_fontsize(


### PR DESCRIPTION
## PR Summary
Addresses several warnings in the docs build and drops CI Upstream runs on pushes to minimize noise.

Remaining warnings in the docs build have to do with our custom gallery configuration.  I'm not really sure what the benefit of this is over something like `sphinx-gallery`, but it looks like we do this in GeoCAT-comp as well.  Addressing those will have to be for another day though. 

Prompted by #360 