### PR TITLE
Drop push trigger for CI Upstream workflow

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -1,6 +1,5 @@
 name: CI Upstream
 on:
-  push:
   workflow_dispatch:
   schedule:
      - cron: '0 0 * * *' # Daily “At 00:00”

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -23,7 +23,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * Group Dependabot updates by `Katelyn FitzGerald`_ in (:pr:`323`)
 * Automatic issue generation for CI Upstream failure by `Katelyn FitzGerald`_ in (:pr:`348`, :pr:`351`)
-* Address docs warnings and adjust CI Upstream runs by `Katelyn FitzGerald`_ in (:pr:`366`)
+* Address docs warnings and adjust CI Upstream runs by `Katelyn FitzGerald`_ in (:pr:`366`, :pr:`367`)
 
 v2025.07.0 (July 16, 2025)
 --------------------------


### PR DESCRIPTION
## PR Summary
When updating the last PR, I must've dropped the commit to change the triggers for the CI Upstream workflow.  This fixes that.