### PR TITLE
Preserve Taylor labels for repeated standard deviations

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,6 +9,10 @@ vYYYY.MM.## (unreleased)
 ------------------------
 This release...
 
+Bug Fixes
+^^^^^^^^^
+* Preserve Taylor diagram model labels when standard deviations repeat by `Yushuo Sun`_ in (:pr:`378`)
+
 Testing
 ^^^^^^^
 * Increase image test tolerances to support Matplotlib 3.11 by `Katelyn FitzGerald`_ in (:pr:`363`)
@@ -226,3 +230,4 @@ Documentation
 .. _`Orhan Eroglu`: https://github.com/erogluorhan
 .. _`Anissa Zacharias`: https://github.com/anissa111
 .. _`Cora Schneck`: https://github.com/cyschneck
+.. _`Yushuo Sun`: https://github.com/yushuosun

--- a/src/geocat/viz/taylor.py
+++ b/src/geocat/viz/taylor.py
@@ -277,8 +277,10 @@ class TaylorDiagram(object):
         std_plot = np_std
         corr_plot = np_corr
 
-        # Create a dictionary of key: std, value: annotated number
-        stdAndNumber = dict(zip(np_std, range(1, len(np_std) + 1)))
+        # Keep model labels tied to their input positions. Standard deviation
+        # values are not unique, so they cannot safely be used as label keys.
+        model_numbers = np.arange(1, len(np_std) + 1)
+        numbers_plot = model_numbers
 
         # If percent_bias_on is True, check inputted arguments
         if percent_bias_on:
@@ -301,8 +303,10 @@ class TaylorDiagram(object):
 
             std_plot = np_std[cond]
             corr_plot = np_corr[cond]
+            numbers_plot = model_numbers[cond]
             std_outlier = np_std[np.bitwise_not(cond)]
             corr_outlier = np_corr[np.bitwise_not(cond)]
+            numbers_outlier = model_numbers[np.bitwise_not(cond)]
             if percent_bias_on:
                 bias_plot = bias_plot[cond]
                 bias_outlier = np.array(bias_array)[np.bitwise_not(cond)]
@@ -348,8 +352,8 @@ class TaylorDiagram(object):
 
         # Annotate model markers if annotate_on is True
         if annotate_on:
-            for std, corr in zip(std_plot, corr_plot):
-                label = str(stdAndNumber[std])
+            for number, std, corr in zip(numbers_plot, std_plot, corr_plot):
+                label = str(number)
                 textObject = self.ax.annotate(
                     label,
                     (np.arccos(corr), std),
@@ -363,7 +367,9 @@ class TaylorDiagram(object):
         # Plot outlier model stats
         if model_outlier_on:
             if len(std_outlier) > 0:
-                for std, corr in zip(std_outlier, corr_outlier):
+                for number, std, corr in zip(
+                    numbers_outlier, std_outlier, corr_outlier
+                ):
                     self.modelOutside += 1  # outlier model number increases
 
                     # Plot markers
@@ -393,7 +399,7 @@ class TaylorDiagram(object):
                     textObject = self.ax.text(
                         0.045 + self.modelOutside * 0.22,
                         -0.08,
-                        str(stdAndNumber[std]),
+                        str(number),
                         fontsize=fontsize,
                         transform=self.ax.transAxes,
                     )

--- a/tests/test_taylor.py
+++ b/tests/test_taylor.py
@@ -21,6 +21,29 @@ def test_add_model_set():
     return fig
 
 
+@pytest.mark.parametrize(
+    'correlations, model_outlier_on',
+    [
+        ([0.32, 0.05, 0.06], False),
+        ([0.32, 0.05, -0.06], True),
+    ],
+)
+def test_add_model_set_preserves_labels_for_duplicate_standard_deviations(
+    correlations, model_outlier_on
+):
+    fig = plt.figure(figsize=(10, 10))
+    taylor = TaylorDiagram(fig=fig, label='REF')
+
+    model_texts, _ = taylor.add_model_set(
+        [0.6, 0.8, 0.6],
+        correlations,
+        model_outlier_on=model_outlier_on,
+    )
+
+    assert [text.get_text() for text in model_texts] == ['1', '2', '3']
+    plt.close(fig)
+
+
 @pytest.mark.mpl_image_compare(tolerance=18, remove_text=True, style='default')
 def test_add_legend():
     fig = plt.figure(figsize=(10, 10))


### PR DESCRIPTION
## PR Summary
Closes #377

Taylor diagram model labels were looked up through a dictionary keyed by standard deviation, so repeated values overwrote earlier model numbers. This change keeps labels tied to input positions and carries those positions through the in-range/outlier split. Regression coverage exercises repeated standard deviations in both paths.

Validation:
- `MPLBACKEND=Agg uv run pytest -q` — 25 passed
- `uv run pre-commit run --all-files` — all hooks passed

## PR Checklist
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [N/A] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.

**Documentation**
- [N/A] Docstrings have been added to all new functions
- [N/A] Docstrings have been updated with any function changes
- [N/A] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [N/A] User facing functions have been added to `docs/user_api/index.rst` under their module

**Examples**
- [N/A] Any new notebook examples added to `docs/examples/` folder
- [N/A] Clear all notebook cells
- [N/A] New notebook files added to `docs/examples.rst` toctree
- [N/A] New notebook files added to new entry in `docs/gallery.yml` with appropriate thumbnail photo in `docs/_static/thumbnails/`