### PR TITLE
Preserve Taylor labels for repeated standard deviations (refresh)

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,6 +9,10 @@ vYYYY.MM.## (unreleased)
 ------------------------
 This release...
 
+Bug Fixes
+^^^^^^^^^
+* Preserve Taylor diagram model labels when standard deviations repeat by `Yushuo Sun`_ in (:pr:`378`)
+
 Testing
 ^^^^^^^
 * Increase image test tolerances to support Matplotlib 3.11 by `Katelyn FitzGerald`_ in (:pr:`363`)
@@ -226,3 +230,4 @@ Documentation
 .. _`Orhan Eroglu`: https://github.com/erogluorhan
 .. _`Anissa Zacharias`: https://github.com/anissa111
 .. _`Cora Schneck`: https://github.com/cyschneck
+.. _`Yushuo Sun`: https://github.com/yushuosun


### PR DESCRIPTION
This is a refresh of #378 against the current main branch.